### PR TITLE
Alias FP to future-ready program

### DIFF
--- a/tabs/pages/api/timetable.js
+++ b/tabs/pages/api/timetable.js
@@ -13,6 +13,7 @@ const subjects = {
   "MF": "Maths",
   "CG": "Computer Science",
   "TU": "Tutorial",
+  "FP": "Future-ready Program"
   "EP": "Extended Project",
   "PH": "Physics",
   "BS": "Business Studies",

--- a/tabs/pages/api/timetable.js
+++ b/tabs/pages/api/timetable.js
@@ -13,7 +13,7 @@ const subjects = {
   "MF": "Maths",
   "CG": "Computer Science",
   "TU": "Tutorial",
-  "FP": "Future-ready Program"
+  "FP": "Future-ready Program",
   "EP": "Extended Project",
   "PH": "Physics",
   "BS": "Business Studies",


### PR DESCRIPTION
- I've received confirmation from HRSFC staff that this is what FP stands for
- In future I may change this again, depending on what the future-ready program turns out to be (and if it's regularly called that, or if we call it tutorial instead, etc.)